### PR TITLE
Ускорение build-deps

### DIFF
--- a/Commands/Build.cs
+++ b/Commands/Build.cs
@@ -1,5 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using Common;
 
 namespace Commands
@@ -52,12 +53,15 @@ namespace Commands
                 return -1;
             }
 
+            var builder = new ModuleBuilder(Log, buildSettings);
+            var builderInitTask = Task.Run(() => builder.Init());
+
             new BuildPreparer(Log).GetModulesOrder(moduleName, configuration, out topSortedDeps, out modulesToUpdate, out currentCommitHases);
 
             var builtStorage = BuiltInfoStorage.Deserialize();
             builtStorage.RemoveBuildInfo(moduleName);
 
-            var builder = new ModuleBuilder(Log, buildSettings);
+            builderInitTask.Wait();
             var module = new Dep(moduleName, null, configuration);
             
             BuildDeps.TryNugetRestore(new List<Dep> {module}, builder);

--- a/Commands/BuildDeps.cs
+++ b/Commands/BuildDeps.cs
@@ -45,11 +45,11 @@ namespace Commands
             var moduleName = Path.GetFileName(cwd);
 
             configuration = string.IsNullOrEmpty(configuration) ? "full-build" : configuration;
-
             List<Dep> modulesToBuild;
             List<Dep> topSortedDeps;
             Dictionary<string, string> currentCommitHases;
-
+            var builder = new ModuleBuilder(Log, buildSettings);
+            var builderInitTask = Task.Run(() => builder.Init());
             new BuildPreparer(Log).GetModulesOrder(moduleName, configuration ?? "full-build", out topSortedDeps, out modulesToBuild, out currentCommitHases);
             if (rebuild)
                 modulesToBuild = topSortedDeps;
@@ -57,13 +57,11 @@ namespace Commands
             var builtStorage = BuiltInfoStorage.Deserialize();
             foreach (var dep in modulesToBuild)
                 builtStorage.RemoveBuildInfo(dep.Name);
-
-            var builder = new ModuleBuilder(Log, buildSettings);
             
+            builderInitTask.Wait();
             TryNugetRestore(modulesToBuild, builder);
-
             int built = 1;
-            for (var i = 0; i < topSortedDeps.Count - 1; i++)
+            for (var i = 0; i < topSortedDeps.Count; i++)
             {
                 var dep = topSortedDeps[i];
 
@@ -92,7 +90,6 @@ namespace Commands
                 built++;
             }
             builtStorage.Save();
-
             Log.Debug("msbuild time: " + ModuleBuilder.TotalMsbuildTime);
             return 0;
         }

--- a/Commands/BuildDeps.cs
+++ b/Commands/BuildDeps.cs
@@ -51,6 +51,10 @@ namespace Commands
             var builder = new ModuleBuilder(Log, buildSettings);
             var builderInitTask = Task.Run(() => builder.Init());
             new BuildPreparer(Log).GetModulesOrder(moduleName, configuration ?? "full-build", out topSortedDeps, out modulesToBuild, out currentCommitHases);
+            if (modulesToBuild.Count > 0 && modulesToBuild[modulesToBuild.Count - 1].Name == moduleName)
+            {
+                modulesToBuild.RemoveAt(modulesToBuild.Count - 1); //remove root
+            }
             if (rebuild)
                 modulesToBuild = topSortedDeps;
 
@@ -61,7 +65,7 @@ namespace Commands
             builderInitTask.Wait();
             TryNugetRestore(modulesToBuild, builder);
             int built = 1;
-            for (var i = 0; i < topSortedDeps.Count; i++)
+            for (var i = 0; i < topSortedDeps.Count - 1; i++)
             {
                 var dep = topSortedDeps[i];
 

--- a/Commands/PackCommand.cs
+++ b/Commands/PackCommand.cs
@@ -44,6 +44,7 @@ namespace Commands
             {
                 XmlDocumentHelper.Save(patchedDocument, projectPath, "\n");
                 var moduleBuilder = new ModuleBuilder(Log, buildSettings);
+                moduleBuilder.Init();
                 ConsoleWriter.WriteInfo("start pack");
                 moduleBuilder.DotnetPack(modulePath, projectPath, buildData?.Configuration ?? "Release");
             }

--- a/Common/BuildPreparer.cs
+++ b/Common/BuildPreparer.cs
@@ -23,7 +23,6 @@ namespace Common
             var configsGraph = BuildConfigsGraph(moduleName, configuration);
             configsGraph = EraseExtraChildren(configsGraph);
             topSortedVertices = GetTopologicallySortedGraph(configsGraph, moduleName, configuration);
-            topSortedVertices.RemoveAt(topSortedVertices.Count - 1); // remove root 
             
             log.Debug("Getting current commit hashes");
             ConsoleWriter.WriteProgress("Getting current commit hashes");

--- a/Common/BuildPreparer.cs
+++ b/Common/BuildPreparer.cs
@@ -20,16 +20,15 @@ namespace Common
         {
             log.Debug("Building configurations graph");
             ConsoleWriter.WriteProgress("Building configurations graph");
-
             var configsGraph = BuildConfigsGraph(moduleName, configuration);
             configsGraph = EraseExtraChildren(configsGraph);
             topSortedVertices = GetTopologicallySortedGraph(configsGraph, moduleName, configuration);
-
+            topSortedVertices.RemoveAt(topSortedVertices.Count - 1); // remove root 
+            
             log.Debug("Getting current commit hashes");
             ConsoleWriter.WriteProgress("Getting current commit hashes");
             currentCommitHashes = GetCurrentCommitHashes(configsGraph);
             updatedModules = BuiltInfoStorage.Deserialize().GetUpdatedModules(topSortedVertices, currentCommitHashes);
-
             ConsoleWriter.ResetProgress();
         }
 
@@ -149,22 +148,33 @@ namespace Common
             return graph;
         }
 
-        private static void Dfs(Dep dep, Dictionary<Dep, List<Dep>> graph, HashSet<Dep> visitedConfigurations)
+        private static readonly Dictionary<string, bool> DepConfigurationExistsCache = new Dictionary<string, bool>();
+        private static void CheckAndUpdateDepConfiguration(Dep dep)
         {
             dep.UpdateConfigurationIfNull();
-
-            if (Yaml.Exists(dep.Name) && !Yaml.ConfigurationParser(dep.Name).ConfigurationExists(dep.Configuration))
+            var key = dep.ToString();
+            if (!DepConfigurationExistsCache.ContainsKey(key))
             {
-                ConsoleWriter.WriteWarning($"Configuration '{dep.Configuration}' was not found in {dep.Name}. Will take full-build config");
+                if (!Directory.Exists(Path.Combine(Helper.CurrentWorkspace, dep.Name)))
+                {
+                    throw new CementBuildException("Failed to find module '" + dep.Name + "'");
+                }
+                DepConfigurationExistsCache[key] = !Yaml.Exists(dep.Name) ||
+                    Yaml.ConfigurationParser(dep.Name).ConfigurationExists(dep.Configuration);
+            }
+            if (!DepConfigurationExistsCache[key])
+            {
+                ConsoleWriter.WriteWarning(
+                    $"Configuration '{dep.Configuration}' was not found in {dep.Name}. Will take full-build config");
                 dep.Configuration = "full-build";
             }
+        }
 
+        private static void Dfs(Dep dep, Dictionary<Dep, List<Dep>> graph, HashSet<Dep> visitedConfigurations)
+        {
+            CheckAndUpdateDepConfiguration(dep);
             visitedConfigurations.Add(dep);
             graph[dep] = new List<Dep>();
-            if (!Directory.Exists(Path.Combine(Helper.CurrentWorkspace, dep.Name)))
-            {
-                throw new CementBuildException("Failed to find module '" + dep.Name + "'");
-            }
             var currentDeps = new DepsParser(Path.Combine(Helper.CurrentWorkspace, dep.Name)).Get(dep.Configuration).Deps ?? new List<Dep>();
             currentDeps = currentDeps.Select(d => new Dep(d.Name, null, d.Configuration)).ToList();
             foreach (var d in currentDeps)

--- a/Common/BuiltInfoStorage.cs
+++ b/Common/BuiltInfoStorage.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -73,7 +73,7 @@ namespace Common
 
         public List<Dep> GetUpdatedModules(List<Dep> modules, Dictionary<string, string> currentCommitHashes)
         {
-            return modules.Where(module => IsModuleUpdate(currentCommitHashes, module)).ToList();
+            return modules.AsParallel().Where(module => IsModuleUpdate(currentCommitHashes, module)).ToList();
         }
 
         private bool IsModuleUpdate(Dictionary<string, string> currentCommitHashes, Dep module)

--- a/Common/Dep.cs
+++ b/Common/Dep.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -13,6 +13,7 @@ namespace Common
         public string Treeish { get; set; }
         public string Configuration { get; set; }
         public bool NeedSrc { get; set; }
+        static readonly Dictionary<string, string> DepDefaultConfigurationCache = new Dictionary<string, string>();
 
         public Dep(string name, string treeish = null, string configuration = null)
         {
@@ -53,6 +54,7 @@ namespace Common
                 Configuration = null;
         }
 
+        
         public void UpdateConfigurationIfNull()
         {
             UpdateConfigurationIfNull(Helper.CurrentWorkspace);
@@ -60,9 +62,15 @@ namespace Common
 
         public void UpdateConfigurationIfNull(string workspace)
         {
-            Configuration = Configuration ??
-                            new ConfigurationParser(new FileInfo(Path.Combine(workspace, Name)))
-                                .GetDefaultConfigurationName();
+            if (!string.IsNullOrEmpty(Configuration)) return;
+            var path = Path.Combine(workspace, Name);
+            if (!DepDefaultConfigurationCache.ContainsKey(path))
+            {
+                DepDefaultConfigurationCache[path] =
+                    new ConfigurationParser(new FileInfo(Path.Combine(workspace, Name)))
+                        .GetDefaultConfigurationName();
+            }
+            Configuration = DepDefaultConfigurationCache[path];
         }
 
         private string UnEscapeBadChars(string str)

--- a/Common/ModuleBuilder.cs
+++ b/Common/ModuleBuilder.cs
@@ -18,6 +18,10 @@ namespace Common
         {
             this.log = log;
             this.buildSettings = buildSettings;
+        }
+
+        public void Init()
+        {
             VsDevHelper.ReplaceVariablesToVs();
         }
 

--- a/Tests/BuildTests/TestBuildDepsOrder.cs
+++ b/Tests/BuildTests/TestBuildDepsOrder.cs
@@ -111,8 +111,9 @@ namespace Tests.BuildTests
                 new BuildPreparer(Log).GetModulesOrder("A", null, out topSortedDeps, out modulesToUpdate, out currentCommitHashes);
                 Assert.IsFalse(topSortedDeps.Contains(new Dep("C/client")));
                 Assert.IsTrue(topSortedDeps.Contains(new Dep("C", null, "full-build")));
+                Assert.IsTrue(topSortedDeps.Contains(new Dep("A", null, "full-build")));
                 Assert.IsTrue(topSortedDeps.Contains(new Dep("B", null, "full-build")));
-                Assert.AreEqual(2, topSortedDeps.Count);
+                Assert.AreEqual(3, topSortedDeps.Count);
             }
         }
 
@@ -147,14 +148,16 @@ namespace Tests.BuildTests
                 List<Dep> topSortedDeps;
                 new BuildPreparer(Log).GetModulesOrder("A", null, out topSortedDeps, out modulesToUpdate, out currentCommitHashes);
                 Assert.IsFalse(topSortedDeps.Contains(new Dep("X/client")));
+                Assert.IsTrue(topSortedDeps.Contains(new Dep("A", null, "full-build")));
                 Assert.IsTrue(topSortedDeps.Contains(new Dep("B", null, "full-build")));
                 Assert.IsTrue(topSortedDeps.Contains(new Dep("C", null, "full-build")));
-                Assert.AreEqual(3, topSortedDeps.Count);
+                Assert.AreEqual(4, topSortedDeps.Count);
                 CollectionAssert.AreEqual(new List<Dep>
                 {
                     new Dep("X", null, "full-build"),
                     new Dep("B", null, "full-build"),
-                    new Dep("C", null, "full-build")
+                    new Dep("C", null, "full-build"),
+                    new Dep("A", null, "full-build")
                 }, topSortedDeps);
             }
         }
@@ -183,7 +186,8 @@ namespace Tests.BuildTests
                 new BuildPreparer(Log).GetModulesOrder("A", null, out topSortedDeps, out modulesToUpdate, out currentCommitHashes);
                 Assert.IsFalse(topSortedDeps.Contains(new Dep("X", null, "full-build")));
                 Assert.IsTrue(topSortedDeps.Contains(new Dep("X", null, "client")));
-                Assert.AreEqual(1, topSortedDeps.Count);
+                Assert.IsTrue(topSortedDeps.Contains(new Dep("A", null, "full-build")));
+                Assert.AreEqual(2, topSortedDeps.Count);
             }
         }
 
@@ -213,7 +217,8 @@ namespace Tests.BuildTests
                 CollectionAssert.AreEqual(new List<Dep>
                 {
                     new Dep("A", null, "client"),
-                    new Dep("X", null, "full-build")
+                    new Dep("X", null, "full-build"),
+                    new Dep("A", null, "full-build")
                 }, topSortedDeps);
             }
         }

--- a/Tests/BuildTests/TestBuildDepsOrder.cs
+++ b/Tests/BuildTests/TestBuildDepsOrder.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Common;
@@ -111,9 +111,8 @@ namespace Tests.BuildTests
                 new BuildPreparer(Log).GetModulesOrder("A", null, out topSortedDeps, out modulesToUpdate, out currentCommitHashes);
                 Assert.IsFalse(topSortedDeps.Contains(new Dep("C/client")));
                 Assert.IsTrue(topSortedDeps.Contains(new Dep("C", null, "full-build")));
-                Assert.IsTrue(topSortedDeps.Contains(new Dep("A", null, "full-build")));
                 Assert.IsTrue(topSortedDeps.Contains(new Dep("B", null, "full-build")));
-                Assert.AreEqual(3, topSortedDeps.Count);
+                Assert.AreEqual(2, topSortedDeps.Count);
             }
         }
 
@@ -148,16 +147,14 @@ namespace Tests.BuildTests
                 List<Dep> topSortedDeps;
                 new BuildPreparer(Log).GetModulesOrder("A", null, out topSortedDeps, out modulesToUpdate, out currentCommitHashes);
                 Assert.IsFalse(topSortedDeps.Contains(new Dep("X/client")));
-                Assert.IsTrue(topSortedDeps.Contains(new Dep("A", null, "full-build")));
                 Assert.IsTrue(topSortedDeps.Contains(new Dep("B", null, "full-build")));
                 Assert.IsTrue(topSortedDeps.Contains(new Dep("C", null, "full-build")));
-                Assert.AreEqual(4, topSortedDeps.Count);
+                Assert.AreEqual(3, topSortedDeps.Count);
                 CollectionAssert.AreEqual(new List<Dep>
                 {
                     new Dep("X", null, "full-build"),
                     new Dep("B", null, "full-build"),
-                    new Dep("C", null, "full-build"),
-                    new Dep("A", null, "full-build")
+                    new Dep("C", null, "full-build")
                 }, topSortedDeps);
             }
         }
@@ -186,8 +183,7 @@ namespace Tests.BuildTests
                 new BuildPreparer(Log).GetModulesOrder("A", null, out topSortedDeps, out modulesToUpdate, out currentCommitHashes);
                 Assert.IsFalse(topSortedDeps.Contains(new Dep("X", null, "full-build")));
                 Assert.IsTrue(topSortedDeps.Contains(new Dep("X", null, "client")));
-                Assert.IsTrue(topSortedDeps.Contains(new Dep("A", null, "full-build")));
-                Assert.AreEqual(2, topSortedDeps.Count);
+                Assert.AreEqual(1, topSortedDeps.Count);
             }
         }
 
@@ -217,8 +213,7 @@ namespace Tests.BuildTests
                 CollectionAssert.AreEqual(new List<Dep>
                 {
                     new Dep("A", null, "client"),
-                    new Dep("X", null, "full-build"),
-                    new Dep("A", null, "full-build")
+                    new Dep("X", null, "full-build")
                 }, topSortedDeps);
             }
         }

--- a/Tests/CommandsTests/TestGet.cs
+++ b/Tests/CommandsTests/TestGet.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using Common;
 using Common.YamlParsers;
@@ -634,7 +634,7 @@ namespace Tests.CommandsTests
         }
 
         [Test]
-        public void TestGetDepsWithBranches()
+        public void TestGetDepsWithBranchesFullBuild()
         {
             using (var env = new TestEnvironment())
             {
@@ -657,12 +657,30 @@ namespace Tests.CommandsTests
                 env.Get("A");
                 Assert.IsTrue(Directory.Exists(Path.Combine(dir, "C")));
                 Assert.AreEqual("branch1", new GitRepository("C", dir, Log).CurrentLocalTreeish().Value);
+            }
+        }
 
+        [Test]
+        public void TestGetDepsWithBranchesClientBuild()
+        {
+            using (var env = new TestEnvironment())
+            {
+                var dir = env.WorkingDirectory.Path;
+
+                env.CreateRepo("A", new Dictionary<string, DepsContent>
+                {
+                    {"full-build", new DepsContent(null, new List<Dep> {new Dep("B@master")})}
+                });
                 env.CreateRepo("B", new Dictionary<string, DepsContent>
                 {
                     {"full-build", new DepsContent(null, new List<Dep> {new Dep("C@branch1")})},
                     {"client *default", new DepsContent(null, new List<Dep> {new Dep("C@branch2")})}
                 });
+                env.CreateRepo("C", new Dictionary<string, DepsContent>
+                {
+                    {"full-build", new DepsContent(null, new List<Dep>())}
+                }, new[] { "master", "branch1", "branch2" });
+                
                 env.Get("A");
                 Assert.IsTrue(Directory.Exists(Path.Combine(dir, "C")));
                 Assert.AreEqual("branch2", new GitRepository("C", dir, Log).CurrentLocalTreeish().Value);


### PR DESCRIPTION
Ускорил работу команды cm build-deps в случае когда все зависимости уже собраны. 
Такой сценарий распространен при сборке на teamcity.
Ускорение почти в 3 раза. На моем компе 32 секунд против 12 секунд.
Что конкретно изменено:
1. Ускорен DFS. В каждом шаге обхода постоянно проверяется наличие папки и вычитывается конфигурационный файл. Для одного модуля эта операция делается по многу раз. Добавил кэширование.
2. В результате выполнения метода BuildPreparer.GetModulesOrder возвращается и сам модуль. Из-за этого дальше по коду был костыль и всегда делался nuget restore. Сделал доп. проверку.
3. Проставление параметров окружения как в VS долгое - 8 сек. Распараллелил и нивелировал его влияние.
4. Немного ускорил метод GetUpdatedModules добавив AsParallel, что дает пару секунд выигрыша.
