### PR TITLE
Add multi-branch force

### DIFF
--- a/Commands/ConvertSpec.cs
+++ b/Commands/ConvertSpec.cs
@@ -74,7 +74,7 @@ namespace Commands
             if (deps.Force != null)
             {
                 deps.Force = deps.Force.Select(x => x.Replace("%CURRENT_BRANCH%", "$CURRENT_BRANCH")).ToArray();
-                writer.WriteLine("    - force: " + deps.Force);
+                writer.WriteLine("    - force: " + string.Join(",", deps.Force));
             }
             if (deps.Deps == null)
                 return;

--- a/Commands/ConvertSpec.cs
+++ b/Commands/ConvertSpec.cs
@@ -73,7 +73,7 @@ namespace Commands
             writer.WriteLine("  deps:");
             if (deps.Force != null)
             {
-                deps.Force = deps.Force.Replace("%CURRENT_BRANCH%", "$CURRENT_BRANCH");
+                deps.Force = deps.Force.Select(x => x.Replace("%CURRENT_BRANCH%", "$CURRENT_BRANCH")).ToArray();
                 writer.WriteLine("    - force: " + deps.Force);
             }
             if (deps.Deps == null)

--- a/Common/DepsIniParser.cs
+++ b/Common/DepsIniParser.cs
@@ -54,10 +54,10 @@ namespace Common
             return deps;
         }
 
-        private string GetForceFromIni(IniData parsed)
+        private string[] GetForceFromIni(IniData parsed)
         {
             var force = parsed.GetValue("force", "main");
-            return force == "" ? null : force;
+            return force == "" ? null : force.Split(',');
         }
     }
 }

--- a/Common/YamlParsers/ConfigurationYamlParser.cs
+++ b/Common/YamlParsers/ConfigurationYamlParser.cs
@@ -141,10 +141,10 @@ namespace Common.YamlParsers
 
     public class DepsContent
     {
-        public string Force { get; set; }
+        public string[] Force { get; set; }
         public List<Dep> Deps { get; set; }
 
-        public DepsContent(string force, List<Dep> deps)
+        public DepsContent(string[] force, List<Dep> deps)
         {
             Force = force;
             Deps = deps;

--- a/Common/YamlParsers/DepsYamlParser.cs
+++ b/Common/YamlParsers/DepsYamlParser.cs
@@ -155,14 +155,14 @@ sdk:
                 return new DepsContent(null, new List<Dep>());
 
             var deps = new List<Dep>();
-            string force = null;
+            string[] force = null;
             foreach (var depSection in (List<object>) configSection["deps"])
             {
                 if (depSection is Dictionary<object, object>)
                 {
                     var dict = depSection as Dictionary<object, object>;
                     if (dict.Keys.Count == 1 && (string) dict.Keys.First() == "force")
-                        force = (string) dict.Values.First();
+                        force = ((string) dict.Values.First()).Split(',');
                     else
                         deps.Add(GetDepFromDictFormat(dict));
                 }

--- a/README-module.yaml.md
+++ b/README-module.yaml.md
@@ -34,7 +34,12 @@ Example:
         - topology
         # to prefer current branch in deps
         - force: $CURRENT_BRANCH
-        # or use <moduleName>@$CURRENT_BRANCH to prefer current branch in some module
+        # or use <moduleName>@$CURRENT_BRANCH to prefer current branch in some module;
+        # you can also choose any specific branch name in deps:
+        # - force: mybestbranch
+        # or provide a comma-separated list of preferred branches:
+        # - force: mybestbranch,notsogoodbranch,leastfavoritebranch
+        # master branch is always the default option if all forced branches are missing
 
       # information on build of the present module in the present configuration
       build:

--- a/Tests/CommandsTests/TestConvertSpec.cs
+++ b/Tests/CommandsTests/TestConvertSpec.cs
@@ -63,7 +63,7 @@ namespace Tests.CommandsTests
 
             var readedDeps = new DepsIniParser(new FileInfo(depsFileName)).Get();
             CollectionAssert.AreEquivalent(readedDeps.Deps, deps);
-            Assert.AreEqual(force, readedDeps.Force.Single());
+            Assert.AreEqual(force, readedDeps.Force?.Single());
         }
 
         private static void WriteDeps(List<Dep> deps, string force, string depsFileName)

--- a/Tests/CommandsTests/TestConvertSpec.cs
+++ b/Tests/CommandsTests/TestConvertSpec.cs
@@ -63,7 +63,7 @@ namespace Tests.CommandsTests
 
             var readedDeps = new DepsIniParser(new FileInfo(depsFileName)).Get();
             CollectionAssert.AreEquivalent(readedDeps.Deps, deps);
-            Assert.AreEqual(force, readedDeps.Force);
+            Assert.AreEqual(force, readedDeps.Force.Single());
         }
 
         private static void WriteDeps(List<Dep> deps, string force, string depsFileName)
@@ -105,7 +105,7 @@ namespace Tests.CommandsTests
 
             var yamlDeps = Yaml.DepsParser("module").Get();
             CollectionAssert.AreEqual(deps, yamlDeps.Deps);
-            Assert.AreEqual("$CURRENT_BRANCH", yamlDeps.Force);
+            Assert.AreEqual("$CURRENT_BRANCH", yamlDeps.Force.Single());
         }
 
         [Test]

--- a/Tests/CommandsTests/TestGet.cs
+++ b/Tests/CommandsTests/TestGet.cs
@@ -113,7 +113,7 @@ namespace Tests.CommandsTests
 
                 env.CreateRepo("A", new Dictionary<string, DepsContent>
                 {
-                    {"full-build", new DepsContent("new", new List<Dep> {new Dep("B")})}
+                    {"full-build", new DepsContent(new[] {"new"}, new List<Dep> {new Dep("B")})}
                 });
                 env.CreateRepo("B", null, new[] {"new"});
                 env.Get("A");
@@ -129,7 +129,7 @@ namespace Tests.CommandsTests
             {
                 env.CreateRepo("A", new Dictionary<string, DepsContent>
                 {
-                    {"full-build", new DepsContent("new", new List<Dep> {new Dep("B")})}
+                    {"full-build", new DepsContent(new[] {"new"}, new List<Dep> {new Dep("B")})}
                 });
                 env.CreateRepo("B", null, new[] {"new"});
                 env.Get("A");
@@ -147,7 +147,7 @@ namespace Tests.CommandsTests
 
                 env.CreateRepo("A", new Dictionary<string, DepsContent>
                 {
-                    {"full-build", new DepsContent("new", new List<Dep> {new Dep("B")})}
+                    {"full-build", new DepsContent(new[] {"new"}, new List<Dep> {new Dep("B")})}
                 });
                 env.CreateRepo("B", null, new[] {"new"});
                 env.Get("A");
@@ -170,7 +170,7 @@ namespace Tests.CommandsTests
 
                 env.CreateRepo("A", new Dictionary<string, DepsContent>
                 {
-                    {"full-build", new DepsContent("new", new List<Dep> {new Dep("B")})}
+                    {"full-build", new DepsContent(new[] {"new"}, new List<Dep> {new Dep("B")})}
                 });
                 env.CreateRepo("B", null, new[] {"new"});
                 env.Get("A");
@@ -268,7 +268,7 @@ namespace Tests.CommandsTests
 
                 env.CreateRepo("A", new Dictionary<string, DepsContent>
                 {
-                    {"full-build", new DepsContent("%CURRENT_BRANCH%", new List<Dep> {new Dep("B")})}
+                    {"full-build", new DepsContent(new[] {"%CURRENT_BRANCH%"}, new List<Dep> {new Dep("B")})}
                 }, new[] {"new"}, DepsFormatStyle.Ini);
                 env.Checkout("A", "new");
 
@@ -289,7 +289,7 @@ namespace Tests.CommandsTests
 
                 env.CreateRepo("A", new Dictionary<string, DepsContent>
                 {
-                    {"full-build", new DepsContent("%CURRENT_BRANCH%", new List<Dep> {new Dep("B")})}
+                    {"full-build", new DepsContent(new[]  {"%CURRENT_BRANCH%"}, new List<Dep> {new Dep("B")})}
                 }, new[] {"new"}, DepsFormatStyle.Ini);
                 env.Checkout("A", "new");
 
@@ -313,7 +313,7 @@ namespace Tests.CommandsTests
 
                 env.CreateRepo("A", new Dictionary<string, DepsContent>
                 {
-                    {"full-build", new DepsContent("new", new List<Dep> {new Dep("B")})}
+                    {"full-build", new DepsContent(new[] {"new"}, new List<Dep> {new Dep("B")})}
                 }, new[] {"new"}, DepsFormatStyle.Ini);
 
                 env.CreateRepo("B", new Dictionary<string, DepsContent>
@@ -339,7 +339,7 @@ namespace Tests.CommandsTests
 
                 env.CreateRepo("A", new Dictionary<string, DepsContent>
                 {
-                    {"full-build", new DepsContent("$CURRENT_BRANCH", new List<Dep> {new Dep("B")})}
+                    {"full-build", new DepsContent(new[] {"$CURRENT_BRANCH"}, new List<Dep> {new Dep("B")})}
                 }, new[] {"new"});
                 env.Checkout("A", "new");
 
@@ -680,7 +680,7 @@ namespace Tests.CommandsTests
                 {
                     {"full-build", new DepsContent(null, new List<Dep>())}
                 }, new[] { "master", "branch1", "branch2" });
-                
+
                 env.Get("A");
                 Assert.IsTrue(Directory.Exists(Path.Combine(dir, "C")));
                 Assert.AreEqual("branch2", new GitRepository("C", dir, Log).CurrentLocalTreeish().Value);

--- a/Tests/CommandsTests/TestGet.cs
+++ b/Tests/CommandsTests/TestGet.cs
@@ -123,6 +123,42 @@ namespace Tests.CommandsTests
         }
 
         [Test]
+        public void TestGetDepsOneDepWithMultipleForce()
+        {
+            using (var env = new TestEnvironment())
+            {
+                var dir = env.WorkingDirectory.Path;
+
+                env.CreateRepo("A", new Dictionary<string, DepsContent>
+                {
+                    {"full-build", new DepsContent(new[] {"priority", "new"}, new List<Dep> {new Dep("B")})}
+                });
+                env.CreateRepo("B", null, new[] {"new", "priority"});
+                env.Get("A");
+                Assert.IsTrue(Directory.Exists(Path.Combine(dir, "A")));
+                Assert.AreEqual("priority", new GitRepository("B", dir, Log).CurrentLocalTreeish().Value);
+            }
+        }
+
+        [Test]
+        public void TestGetDepsOneDepWithMultipleForceOneBranchMissing()
+        {
+            using (var env = new TestEnvironment())
+            {
+                var dir = env.WorkingDirectory.Path;
+
+                env.CreateRepo("A", new Dictionary<string, DepsContent>
+                {
+                    {"full-build", new DepsContent(new[] {"missing", "priority", "new"}, new List<Dep> {new Dep("B")})}
+                });
+                env.CreateRepo("B", null, new[] {"new", "priority"});
+                env.Get("A");
+                Assert.IsTrue(Directory.Exists(Path.Combine(dir, "A")));
+                Assert.AreEqual("priority", new GitRepository("B", dir, Log).CurrentLocalTreeish().Value);
+            }
+        }
+
+        [Test]
         public void TestGetDepsOneDepWithResetThrowsDueToPolicy()
         {
             using (var env = new TestEnvironment())

--- a/Tests/Helpers/TestEnvironment.cs
+++ b/Tests/Helpers/TestEnvironment.cs
@@ -117,7 +117,7 @@ full-build:
   deps:{
                             (depsByConfig[config]
                                  .Force != null
-                                ? "\r\n    - force: " + depsByConfig[config].Force
+                                ? $"\r\n    - force: " + string.Join(",", depsByConfig[config].Force)
                                 : "")
                         }
 ", (current, dep) => current +
@@ -144,7 +144,7 @@ full-build:
                 {
                     content = depsByConfig[config].Force != null
                         ? @"[main]
-force = " + depsByConfig[config].Force + "\r\n"
+force = " + string.Join(",", depsByConfig[config].Force) + "\r\n"
                         : "";
                     foreach (var dep in depsByConfig[config].Deps)
                     {

--- a/Tests/ParsersTests/TestDepParser.cs
+++ b/Tests/ParsersTests/TestDepParser.cs
@@ -27,6 +27,23 @@ client:";
         }
 
         [Test]
+        public void TestGetDepsMultipleForce()
+        {
+            var text = @"
+default:
+    deps:
+        - force: priority,master
+        - A
+        - B
+client:";
+            var depsContent = YamlFromText.DepsParser(text).Get("client");
+            CollectionAssert.AreEqual(new[] {"priority", "master"}, depsContent.Force.ToArray());
+            Assert.AreEqual(2, depsContent.Deps.Count);
+            Assert.AreEqual("A", depsContent.Deps[0].Name);
+            Assert.AreEqual("B", depsContent.Deps[1].Name);
+        }
+
+        [Test]
         public void TestForceNotFirstLine()
         {
             var text = @"

--- a/Tests/ParsersTests/TestDepParser.cs
+++ b/Tests/ParsersTests/TestDepParser.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Common;
 using NUnit.Framework;
 using Tests.Helpers;
@@ -19,7 +20,7 @@ default:
         - B
 client:";
             var depsContent = YamlFromText.DepsParser(text).Get("client");
-            Assert.AreEqual("master", depsContent.Force);
+            Assert.AreEqual("master", depsContent.Force.Single());
             Assert.AreEqual(2, depsContent.Deps.Count);
             Assert.AreEqual("A", depsContent.Deps[0].Name);
             Assert.AreEqual("B", depsContent.Deps[1].Name);
@@ -36,7 +37,7 @@ default:
         - B
 client:";
             var depsContent = YamlFromText.DepsParser(text).Get("client");
-            Assert.AreEqual("master", depsContent.Force);
+            Assert.AreEqual("master", depsContent.Force.Single());
             Assert.AreEqual(2, depsContent.Deps.Count);
             Assert.AreEqual("A", depsContent.Deps[0].Name);
             Assert.AreEqual("B", depsContent.Deps[1].Name);
@@ -55,7 +56,7 @@ client:
     deps:
         - C";
             var depsContent = YamlFromText.DepsParser(text).Get("client");
-            Assert.AreEqual("master", depsContent.Force);
+            Assert.AreEqual("master", depsContent.Force.Single());
             Assert.AreEqual(3, depsContent.Deps.Count);
             Assert.AreEqual("A", depsContent.Deps[0].Name);
             Assert.AreEqual("B", depsContent.Deps[1].Name);
@@ -75,7 +76,7 @@ client:
     deps:
         - C";
             var depsContent = YamlFromText.DepsParser(text).Get("sdk");
-            Assert.AreEqual("master", depsContent.Force);
+            Assert.AreEqual("master", depsContent.Force.Single());
             Assert.AreEqual(3, depsContent.Deps.Count);
             Assert.AreEqual("C", depsContent.Deps[0].Name);
             Assert.AreEqual("A", depsContent.Deps[1].Name);
@@ -220,7 +221,7 @@ default:
 full-build:
     deps:";
             var dc = YamlFromText.DepsParser(text).Get();
-            Assert.AreEqual("a -> b\nc -> b\n$CURRENT_BRANCH\n", dc.Force);
+            Assert.AreEqual("a -> b\nc -> b\n$CURRENT_BRANCH\n", dc.Force.Single());
         }
 
         [Test]
@@ -260,7 +261,7 @@ client:
     - B/full-build
 ";
             var dc = YamlFromText.DepsParser(text).Get("client");
-            Assert.AreEqual("master", dc.Force);
+            Assert.AreEqual("master", dc.Force.Single());
             Assert.AreEqual(2, dc.Deps.Count);
             Assert.AreEqual(new Dep("A", "branch", "sdk"), dc.Deps[0]);
             Assert.IsTrue(dc.Deps[0].NeedSrc);
@@ -280,7 +281,7 @@ client:
     - B/full-build
 ";
             var dc = YamlFromText.DepsParser(text).Get("client");
-            Assert.AreEqual("master", dc.Force);
+            Assert.AreEqual("master", dc.Force.Single());
             Assert.AreEqual(2, dc.Deps.Count);
             Assert.AreEqual(new Dep("A", "branch", "sdk"), dc.Deps[0]);
             Assert.IsFalse(dc.Deps[0].NeedSrc);

--- a/Tests/ParsersTests/TestParseIniDeps.cs
+++ b/Tests/ParsersTests/TestParseIniDeps.cs
@@ -1,4 +1,5 @@
-﻿using Common;
+﻿using System.Linq;
+using Common;
 using NUnit.Framework;
 
 namespace Tests.ParsersTests
@@ -32,7 +33,7 @@ config = sdk
 A -> B
 C -> B
 $CURRENT_BRANCH";
-            Assert.AreEqual(expectedForce, depsContent.Force);
+            Assert.AreEqual(expectedForce, depsContent.Force.Single());
             Assert.AreEqual(4, deps.Count);
             Assert.AreEqual("A", deps[0].Name);
             Assert.AreEqual("develop", deps[0].Treeish);

--- a/Tests/ParsersTests/TestProjectFile.cs
+++ b/Tests/ParsersTests/TestProjectFile.cs
@@ -259,7 +259,7 @@ namespace Tests.ParsersTests
             projectFile.AddAnalyzer(analyzerDllFullPath);
 
             Assert.AreEqual(0, SearchByXpath(projectFile.Document, "//a:ItemGroup/a:Analyzer[@Include = 'Another.dll']").Count);
-            Assert.AreEqual(1, SearchByXpath(projectFile.Document, "//a:ItemGroup/a:Analyzer[@Include = 'dummyDir/Another.dll']").Count);
+            Assert.AreEqual(1, SearchByXpath(projectFile.Document, "//a:ItemGroup/a:Analyzer[@Include = 'dummyDir\\Another.dll']").Count);
         }
 
 

--- a/Tests/ParsersTests/TestProjectFile.cs
+++ b/Tests/ParsersTests/TestProjectFile.cs
@@ -168,7 +168,7 @@ namespace Tests.ParsersTests
             Assert.IsTrue(proj.ContainsRef("log4net", out refXml));
             Assert.AreEqual("abc/def", refXml.LastChild.InnerText);
         }
-        
+
         [Test]
         public void Costructor_GetXmlFromFile_IfFileExist()
         {
@@ -259,7 +259,7 @@ namespace Tests.ParsersTests
             projectFile.AddAnalyzer(analyzerDllFullPath);
 
             Assert.AreEqual(0, SearchByXpath(projectFile.Document, "//a:ItemGroup/a:Analyzer[@Include = 'Another.dll']").Count);
-            Assert.AreEqual(1, SearchByXpath(projectFile.Document, "//a:ItemGroup/a:Analyzer[@Include = 'dummyDir\\Another.dll']").Count);
+            Assert.AreEqual(1, SearchByXpath(projectFile.Document, "//a:ItemGroup/a:Analyzer[@Include = 'dummyDir/Another.dll']").Count);
         }
 
 
@@ -280,7 +280,7 @@ namespace Tests.ParsersTests
     <RepositoryUrl>https://github.com/vostok-project/clusterclient</RepositoryUrl>
     <PackageTags>vostok clusterclient</PackageTags>
   </PropertyGroup>
-            
+
   <ItemGroup>
     <Reference Include = ""Vostok.Core"" >
         <HintPath>..\..\vostok.core\Vostok.Core\bin\Release\netstandard2.0\Vostok.Core.dll </HintPath>
@@ -288,7 +288,7 @@ namespace Tests.ParsersTests
   </ItemGroup>
 </Project>
             ";
-            
+
             var proj = CreateProjectFile(content);
             var xmlDocument = proj.CreateCsProjWithNugetReferences(new List<Dep> { new Dep("vostok.core") }, true);
 

--- a/Tests/ParsersTests/TestRulesetFile.cs
+++ b/Tests/ParsersTests/TestRulesetFile.cs
@@ -86,7 +86,7 @@ namespace Tests.ParsersTests
             var dummyPath = Path.Combine(workDirectory.Path, $"{Guid.NewGuid()}.ruleset");
             var rulesetFile = new RulesetFile(dummyPath);
 
-            var expectedRelRulesetPath = $"../dummyFolder/{Guid.NewGuid()}.ruleset";
+            var expectedRelRulesetPath = $"..\\dummyFolder\\{Guid.NewGuid()}.ruleset";
             var absoluteRulesetPath = Path.GetFullPath(Path.Combine(workDirectory.Path, expectedRelRulesetPath));
             rulesetFile.Include(absoluteRulesetPath);
 

--- a/Tests/ParsersTests/TestRulesetFile.cs
+++ b/Tests/ParsersTests/TestRulesetFile.cs
@@ -86,7 +86,7 @@ namespace Tests.ParsersTests
             var dummyPath = Path.Combine(workDirectory.Path, $"{Guid.NewGuid()}.ruleset");
             var rulesetFile = new RulesetFile(dummyPath);
 
-            var expectedRelRulesetPath = $"..\\dummyFolder\\{Guid.NewGuid()}.ruleset";
+            var expectedRelRulesetPath = $"../dummyFolder/{Guid.NewGuid()}.ruleset";
             var absoluteRulesetPath = Path.GetFullPath(Path.Combine(workDirectory.Path, expectedRelRulesetPath));
             rulesetFile.Include(absoluteRulesetPath);
 


### PR DESCRIPTION
Current syntax:

```
force: A
```

...means: use A or else master.

New proposed syntax:

```
force: A,B
```

..means: use A or else B or else master.