### PR TITLE
Correct paths for "cm ref add" on Unix systems

### DIFF
--- a/Commands/RefAdd.cs
+++ b/Commands/RefAdd.cs
@@ -147,11 +147,19 @@ namespace Commands
 
             foreach (var buildItem in installData.BuildFiles)
             {
-                var refName = Path.GetFileNameWithoutExtension(buildItem);
-                var hintPath = Helper.GetRelativePath(Path.Combine(Helper.CurrentWorkspace, buildItem),
+                var buildItemPath = Helper.OsIsUnix() ? Helper.WindowsPathSlashesToUnix(buildItem) : buildItem;
+                var refName = Path.GetFileNameWithoutExtension(buildItemPath);
+
+                var hintPath = Helper.GetRelativePath(Path.Combine(Helper.CurrentWorkspace, buildItemPath),
                     Directory.GetParent(projectPath).FullName);
+
+                if (Helper.OsIsUnix())
+                {
+                    hintPath = Helper.UnixPathSlashesToWindows(hintPath);
+                }
+
                 AddRef(csproj, refName, hintPath);
-                CheckExistBuildFile(Path.Combine(Helper.CurrentWorkspace, buildItem));
+                CheckExistBuildFile(Path.Combine(Helper.CurrentWorkspace, buildItemPath));
             }
 
             if (!testReplaces)

--- a/Common/Helper.cs
+++ b/Common/Helper.cs
@@ -325,5 +325,15 @@ namespace Common
         {
             return text.Replace("\r\n", "\n");
         }
+
+        public static string UnixPathSlashesToWindows(string path)
+        {
+            return path.Replace('/', '\\');
+        }
+
+        public static string WindowsPathSlashesToUnix(string path)
+        {
+            return path.Replace('\\', '/');
+        }
     }
 }

--- a/Common/ModuleBuilderHelper.cs
+++ b/Common/ModuleBuilderHelper.cs
@@ -13,6 +13,9 @@ namespace Common
 
         public static string FindMsBuild(string version, string moduleName)
         {
+            if (Helper.OsIsUnix())
+                return FindMsBuildUnix(version, moduleName);
+
             var msBuilds = FindAviableMsBuilds();
 
             if (version != null)
@@ -21,6 +24,18 @@ namespace Common
             if (!msBuilds.Any())
                 throw new CementException($"Failed to find msbuild.exe {version ?? ""} for {moduleName}");
             return msBuilds.First().Value;
+        }
+
+        private static string FindMsBuildUnix(string version, string moduleName)
+        {
+            var monoRuntime = Type.GetType("Mono.Runtime");
+            if (monoRuntime == null)
+                throw new CementException($"Failed to find msbuild.exe {version ?? ""} for {moduleName}");
+            var monoRuntimePath = monoRuntime.Assembly.Location;
+            var monoRuntimeDir = Path.GetDirectoryName(monoRuntimePath);
+            if (monoRuntimeDir == null)
+                throw new CementException($"Failed to find msbuild.exe {version ?? ""} for {moduleName}");
+            return Path.Combine(monoRuntimeDir, "../msbuild/15.0/bin/");
         }
 
         private static List<KeyValuePair<string, string>> msBuildsCache;


### PR DESCRIPTION
Since windows-style paths are used in module.yaml for artifacts and csproj-files for hint paths, cement has to translate them to unix style and back while checking artifacts.
Also fixed location of MSBuild on Unix systems.