### PR TITLE
feature: add  '--recursive' flag to git clone command

### DIFF
--- a/Common/GitRepository.cs
+++ b/Common/GitRepository.cs
@@ -46,7 +46,7 @@ namespace Common
             log.LogInformation($"{"[" + ModuleName + "]",-30}Cloning treeish {treeish ?? "master"} into {RepoPath}");
             var treeishSuffix = "-b " + (treeish ?? "master");
             var depthSuffix = depth.HasValue ? $" --depth {depth.Value} --no-single-branch" : "";
-            var cmd = $"git clone {url} {treeishSuffix}{depthSuffix} \"{RepoPath}\" 2>&1";
+            var cmd = $"git clone --recursive {url} {treeishSuffix}{depthSuffix} \"{RepoPath}\" 2>&1";
             var exitCode = runner.Run(cmd, TimeSpan.FromMinutes(60), RetryStrategy.IfTimeoutOrFailed);
             if (exitCode != 0)
             {


### PR DESCRIPTION
Our team uses git submodules to get non-binary dependencies (like https://github.com/vostok/devtools), but currently the Cement doesn't know how to work with them.

In this commit, I added only '--recursive' flag in the GitRepository.Clone command. This changes are not breaking, but very usefully for us ^__^.