### PR TITLE
Внутри инициализации MaxDegreeOfParallelism есть использование LockOb…

### DIFF
--- a/Common/Helper.cs
+++ b/Common/Helper.cs
@@ -18,10 +18,10 @@ namespace Common
         public const string CementDirectory = ".cement";
         public const string YamlSpecFile = "module.yaml";
         public const string ConfigurationDelimiter = "/";
+        public static readonly object LockObject = new object();
         public static readonly int MaxDegreeOfParallelism = CementSettings.Get().MaxDegreeOfParallelism ?? 2 * Environment.ProcessorCount;
         public static ParallelOptions ParallelOptions => new ParallelOptions { MaxDegreeOfParallelism = MaxDegreeOfParallelism };
         public static string CurrentWorkspace { get; private set; }
-        public static readonly object LockObject = new object();
         public static readonly object PackageLockObject = new object();
         private static readonly ILogger Log = LogManager.GetLogger(typeof(Helper));
 


### PR DESCRIPTION
…ject. Это приводило к тому, что LockObject оказывался null и всё разваливалось.

Пример стэка исключения:
Unhandled Exception: System.TypeInitializationException: The type initializer for 'Common.Helper' threw an exception. ---> System.ArgumentNullException: Value cannot be null.
   at System.Threading.Monitor.Enter(Object obj)
   at Common.ConsoleWriter.PrintLnError(String text, ConsoleColor color, Boolean emptyLineAfter)
   at Common.ConsoleWriter.WriteError(String error)
   at Common.CementSettings.GetDefaultSettings()
   at Common.CementSettings.Get()
   at Common.Helper..cctor()
   --- End of inner exception stack trace ---
   at cm.EntryPoint.Main(String[] args)