### PR TITLE
Using single quotes on Unix

### DIFF
--- a/Common/ShellRunner.cs
+++ b/Common/ShellRunner.cs
@@ -118,7 +118,8 @@ namespace Common
         public int RunOnce(string commandWithArguments, string workingDirectory, TimeSpan timeout)
         {
             BeforeRun();
-            startInfo.Arguments = startInfo.Arguments + "\"" + commandWithArguments + "\"";
+            var quote = Helper.OsIsUnix() ? '\'' : '"';
+            startInfo.Arguments = startInfo.Arguments + quote + commandWithArguments + quote;
             startInfo.WorkingDirectory = workingDirectory;
 
             var sw = Stopwatch.StartNew();


### PR DESCRIPTION
Use single quotes on Unix-like OSes to avoid expanding escaped characters in build args. Particularly, the` \"` sequence is now preserved as is.
Original problem was with the folowing config:
```
build:
    tool: dotnet
    parameters: build -property:TargetFrameworks=\"net5.0;netcoreapp3.1;netstandard2.0\"
```